### PR TITLE
Prefer Response#send when responding with data

### DIFF
--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -96,7 +96,7 @@ class ExpressMiddleware {
         if (routeUrl === this.setupOptions.metricsRoute) {
             debug('Request to /metrics endpoint');
             res.set('Content-Type', Prometheus.register.contentType);
-            return res.end(Prometheus.register.metrics());
+            return res.send(Prometheus.register.metrics());
         }
         if (routeUrl === `${this.setupOptions.metricsRoute}.json`) {
             debug('Request to /metrics endpoint');


### PR DESCRIPTION
From https://expressjs.com/en/api.html#res.end:

> If you need to respond with data, instead use methods such as res.send() and res.json().

Once this is merged, I'll push a commit to https://github.com/FlatFilers/Mono/pull/1139 that ensures the most recent version is used.