### PR TITLE
Accommodate upstream move to async functions

### DIFF
--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -85,7 +85,7 @@ class ExpressMiddleware {
         return route;
     }
 
-    middleware(req, res, next) {
+    async middleware(req, res, next) {
         if (!this.setupOptions.server && req.socket) {
             this.setupOptions.server = req.socket.server;
             this._collectDefaultServerMetrics(this.setupOptions.defaultMetricsInterval);
@@ -96,11 +96,13 @@ class ExpressMiddleware {
         if (routeUrl === this.setupOptions.metricsRoute) {
             debug('Request to /metrics endpoint');
             res.set('Content-Type', Prometheus.register.contentType);
-            return res.send(Prometheus.register.metrics());
+            const metrics = await Prometheus.register.metrics();
+            return res.send(metrics);
         }
         if (routeUrl === `${this.setupOptions.metricsRoute}.json`) {
             debug('Request to /metrics endpoint');
-            return res.json(Prometheus.register.getMetricsAsJSON());
+            const metrics = await Prometheus.register.getMetricsAsJSON();
+            return res.json(metrics);
         }
 
         req.metrics = {


### PR DESCRIPTION
Applies the change outlined in the release notes of https://github.com/siimon/prom-client/releases/tag/v13.0.0:

> If your metrics server has a line like `res.send(register.metrics())`, you should change it to `res.send(await register.metrics())`.

https://github.com/FlatFilers/prometheus-api-metrics/pull/3 changed `res.end()` to `res.send()`, but turns out this was necessary as well and spelled out in the release notes this whole time. I'll follow up with another PR to bump the version used in prod once this is merged.

/cc https://github.com/FlatFilers/Mono/pull/1096